### PR TITLE
I was researching TSAN craziness and glanced at transpor_test ex/heap…

### DIFF
--- a/src/ipc/transport/struc/sync_io/channel.hpp
+++ b/src/ipc/transport/struc/sync_io/channel.hpp
@@ -4343,9 +4343,13 @@ bool CLASS_SIO_STRUCT_CHANNEL::expect_msgs_impl(Msgs_in* qd_msgs,
     msgs_in_q.pop();
     if (msgs_in_q.empty()) // Empty -> immediately erase.
     {
-      m_rcv_pending_msgs.erase(msgs_in_q_it);
+      m_rcv_pending_msgs.erase(msgs_in_q_it); // msg_in_q now points to garbage (do not touch it).
+      FLOW_LOG_TRACE("Popped 1 (because one-off expectation); queue is now empty.");
     }
-    FLOW_LOG_TRACE("Popped 1 (because one-off expectation); queue is now sized [" << msgs_in_q.size() << "].");
+    else
+    {
+      FLOW_LOG_TRACE("Popped 1 (because one-off expectation); queue is now sized [" << msgs_in_q.size() << "].");
+    }
 
     qd_msgs->emplace_back(Msg_in_ptr(msg_in.release())); // Upgrade to shared_ptr<> by the way.
 


### PR DESCRIPTION
… with DATA-level logging.  Turns out both TSAN and ASAN detect a problem of using heap after free, reliably.  Turns out there is a really straightforward use-after-free -- when trying to log a TRACE-level message, hence not normally seen with INFO-level logging.  Fixing.