### PR TITLE
Boost v1.84 to 1.87 in Flow => slight breaking API changes in flow::error => fix/improve their use in this module. / Boost v1.84 to 1.87 in Flow => fix Boost.uuid use due to changed API.

### DIFF
--- a/src/ipc/transport/struc/channel.hpp
+++ b/src/ipc/transport/struc/channel.hpp
@@ -2331,8 +2331,7 @@ typename CLASS_STRUCTURED_CHANNEL::Msg_in_ptr
   using std::get;
   using std::monostate;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(Msg_in_ptr, Channel::sync_request,
-                                     flow::util::bind_ns::cref(msg), originating_msg_or_null, timeout, _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(Msg_in_ptr, sync_request, msg, originating_msg_or_null, timeout, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   // We are in thread U (not W, by contract, as blocking thread W can delay subsequent handler firing).

--- a/src/ipc/transport/struc/detail/msg_mdt_out.hpp
+++ b/src/ipc/transport/struc/detail/msg_mdt_out.hpp
@@ -165,8 +165,8 @@ Msg_mdt_out<Struct_builder_config>::Msg_mdt_out
   auto capnp_uuid = msg_root->initAuthHeader().initSessionToken();
   static_assert(std::remove_reference_t<decltype(session_token)>::static_size() == 2 * sizeof(uint64_t),
                 "World is broken: UUIDs expected to be 16 bytes!");
-  auto& first8 = *(reinterpret_cast<const uint64_t*>(session_token.data)); // capnp_uuid is aligned OK, so this is too.
-  auto& last8 = *(reinterpret_cast<const uint64_t*>(session_token.data + sizeof(uint64_t))); // As is this.
+  auto& first8 = *(reinterpret_cast<const uint64_t*>(session_token.data())); // capnp_uuid is aligned, so this is too.
+  auto& last8 = *(reinterpret_cast<const uint64_t*>(session_token.data() + sizeof(uint64_t))); // As is this.
   capnp_uuid.setFirst8(native_to_little(first8)); // Reminder: Likely no-op + copy of uint64_t.
   capnp_uuid.setLast8(native_to_little(last8)); // Ditto.
 

--- a/src/ipc/transport/struc/msg.hpp
+++ b/src/ipc/transport/struc/msg.hpp
@@ -1213,8 +1213,8 @@ size_t CLASS_STRUCT_MSG_IN::deserialize_mdt(flow::log::Logger* logger_ptr, Error
   const auto capnp_uuid = auth_header.getSessionToken();
   static_assert(decltype(m_session_token)::static_size() == 2 * sizeof(uint64_t),
                 "World is broken: UUIDs expected to be 16 bytes!");
-  auto& first8 = *(reinterpret_cast<uint64_t*>(m_session_token.data)); // m_session_token is aligned, so this is too.
-  auto& last8 = *(reinterpret_cast<uint64_t*>(m_session_token.data + sizeof(uint64_t))); // As is this.
+  auto& first8 = *(reinterpret_cast<uint64_t*>(m_session_token.data())); // m_session_token is aligned, so this is too.
+  auto& last8 = *(reinterpret_cast<uint64_t*>(m_session_token.data() + sizeof(uint64_t))); // As is this.
   first8 = little_to_native(capnp_uuid.getFirst8()); // Reminder: Likely no-op + copy of uint64_t.
   last8 = little_to_native(capnp_uuid.getLast8()); // Ditto.
 

--- a/src/ipc/transport/struc/sync_io/channel.hpp
+++ b/src/ipc/transport/struc/sync_io/channel.hpp
@@ -4223,14 +4223,11 @@ bool CLASS_SIO_STRUCT_CHANNEL::async_request(const Msg_out& msg, const Msg_in* o
 TEMPLATE_SIO_STRUCT_CHANNEL
 bool CLASS_SIO_STRUCT_CHANNEL::send_impl(const Msg_out& msg_public, const Msg_in* originating_msg_or_null,
                                          Error_code* err_code,
-                                         /* @todo Make it && for a little perf boost.  T&& doesn't play well
-                                          * with FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(), as I recall, so it'll take
-                                          * a bit of maneuvering. */
+                                         // @todo Make it && for a little perf boost.
                                          const On_msg_func_ptr& on_rsp_func_or_null, msg_id_out_t* id_unless_one_off)
 {
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Channel::send_impl, flow::util::bind_ns::cref(msg_public),
-                                     originating_msg_or_null, _1, flow::util::bind_ns::cref(on_rsp_func_or_null),
-                                     id_unless_one_off);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, send_impl,
+                                     msg_public, originating_msg_or_null, _1, on_rsp_func_or_null, id_unless_one_off);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   const auto& msg = static_cast<const Msg_out_impl&>(msg_public);


### PR DESCRIPTION
This is downstream of flow PR https://github.com/Flow-IPC/flow/pull/100.

1, Boost.uuid changed the meaning of `uuid::data`; it was a data member; now it is a method `data()`. Changed those 2 invocations accordingly.

2, quoting above PR's description, namely the part of that relevant to these changes (modulo the UUID thing):

- APIs are unchanged except:
  - a mostly backward-compatible improvement in FLOW_ERROR_EXEC_AND_THROW_ON_ERROR();
    - (but remove any bind_ns::cref() wrappers for args - they're not necessary and won't build)

Basically, in English: FLOW_ERROR_EXEC_AND_THROW_ON_ERROR() invocations have been simplified due to its new impl and improved API.