### PR TITLE
In test/demo programs using the new (albeit optional) flow::log::Config::init_component_to_union_idx_mapping() arg in the now-recommended way.

### DIFF
--- a/test/basic/link_test/main.cpp
+++ b/test/basic/link_test/main.cpp
@@ -64,9 +64,9 @@ int main(int argc, char const * const * argv)
    * Log_context to do this very trivially, but we just have the one function, main(), so far so: */
   Config std_log_config;
   std_log_config.init_component_to_union_idx_mapping<Flow_log_component>
-    (1000, Config::standard_component_payload_enum_sparse_length<Flow_log_component>());
+    (1000, Config::standard_component_payload_enum_sparse_length<Flow_log_component>(), true);
   std_log_config.init_component_to_union_idx_mapping<ipc::Log_component>
-    (2000, Config::standard_component_payload_enum_sparse_length<ipc::Log_component>());
+    (2000, Config::standard_component_payload_enum_sparse_length<ipc::Log_component>(), true);
   std_log_config.init_component_names<Flow_log_component>(flow::S_FLOW_LOG_COMPONENT_NAME_MAP, false, "flow-");
   std_log_config.init_component_names<ipc::Log_component>(ipc::S_IPC_LOG_COMPONENT_NAME_MAP, false, "ipc-");
   Simple_ostream_logger std_logger(&std_log_config);


### PR DESCRIPTION
necessary part of fix to Flow-IPC/flow#94

  To code reviewer:

  Forgoing code review:
  - Am owner.
  - Source code changes are test-only; insignificant and self-explanatory.
